### PR TITLE
Expose onRampStatus function

### DIFF
--- a/packages/panna-sdk/src/core/index.ts
+++ b/packages/panna-sdk/src/core/index.ts
@@ -3,3 +3,4 @@ export * from './chains';
 export * from './wallet';
 export * from './utils';
 export * from './defaults';
+export * from './onramp';

--- a/packages/panna-sdk/src/core/onramp/index.ts
+++ b/packages/panna-sdk/src/core/onramp/index.ts
@@ -1,0 +1,14 @@
+// Export functions
+export { onRampStatus } from './onramp';
+
+// Export types
+export type {
+  OnrampStatus,
+  OnrampTransaction,
+  OnrampPurchaseData,
+  OnrampStatusParams,
+  OnrampStatusResult,
+  OnrampCreatedResult,
+  OnrampPendingResult,
+  OnrampCompletedResult
+} from './types';

--- a/packages/panna-sdk/src/core/onramp/onramp.test.ts
+++ b/packages/panna-sdk/src/core/onramp/onramp.test.ts
@@ -1,0 +1,158 @@
+import { Bridge } from 'thirdweb';
+import type { PannaClient } from '../client';
+import { onRampStatus } from './onramp';
+import type {
+  OnrampCreatedResult,
+  OnrampPendingResult,
+  OnrampCompletedResult
+} from './types';
+
+// Mock thirdweb Bridge module
+jest.mock('thirdweb', () => ({
+  Bridge: {
+    Onramp: {
+      status: jest.fn()
+    }
+  }
+}));
+
+describe('onRampStatus', () => {
+  const mockClient = { clientId: 'test-client-id' } as PannaClient;
+  const mockSessionId = '022218cc-96af-4291-b90c-dadcb47571ec';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return CREATED status successfully', async () => {
+    const mockCreatedResult: OnrampCreatedResult = {
+      status: 'CREATED',
+      transactions: [],
+      purchaseData: {
+        customId: '123',
+        metadata: { source: 'mobile' }
+      }
+    };
+
+    (Bridge.Onramp.status as jest.Mock).mockResolvedValue(mockCreatedResult);
+
+    const result = await onRampStatus({
+      id: mockSessionId,
+      client: mockClient
+    });
+
+    expect(result).toEqual(mockCreatedResult);
+    expect(Bridge.Onramp.status).toHaveBeenCalledWith({
+      id: mockSessionId,
+      client: mockClient
+    });
+  });
+
+  it('should return PENDING status successfully', async () => {
+    const mockPendingResult: OnrampPendingResult = {
+      status: 'PENDING',
+      transactions: [],
+      purchaseData: {
+        userId: 'user-456',
+        purchaseAmount: 100,
+        currency: 'USD'
+      }
+    };
+
+    (Bridge.Onramp.status as jest.Mock).mockResolvedValue(mockPendingResult);
+
+    const result = await onRampStatus({
+      id: mockSessionId,
+      client: mockClient
+    });
+
+    expect(result).toEqual(mockPendingResult);
+    expect(result.status).toBe('PENDING');
+    expect(result.transactions).toHaveLength(0);
+  });
+
+  it('should return COMPLETED status with transactions', async () => {
+    const mockCompletedResult: OnrampCompletedResult = {
+      status: 'COMPLETED',
+      transactions: [
+        {
+          chainId: 1,
+          transactionHash: '0x123abc...'
+        },
+        {
+          chainId: 56,
+          transactionHash: '0x456def...'
+        }
+      ],
+      purchaseData: {
+        sessionId: 'session-789',
+        completedAt: '2024-01-15T10:30:00Z',
+        finalAmount: '100.50'
+      }
+    };
+
+    (Bridge.Onramp.status as jest.Mock).mockResolvedValue(mockCompletedResult);
+
+    const result = await onRampStatus({
+      id: mockSessionId,
+      client: mockClient
+    });
+
+    expect(result).toEqual(mockCompletedResult);
+    expect(result.status).toBe('COMPLETED');
+    expect(result.transactions).toHaveLength(2);
+    expect(result.transactions[0].chainId).toBe(1);
+    expect(result.transactions[0].transactionHash).toBe('0x123abc...');
+  });
+
+  it('should handle errors from thirdweb API', async () => {
+    const mockError = new Error('API request failed');
+    (Bridge.Onramp.status as jest.Mock).mockRejectedValue(mockError);
+
+    await expect(
+      onRampStatus({
+        id: mockSessionId,
+        client: mockClient
+      })
+    ).rejects.toThrow(
+      `Failed to get onramp status for session ${mockSessionId}: API request failed`
+    );
+  });
+
+  it('should handle non-Error objects thrown by API', async () => {
+    (Bridge.Onramp.status as jest.Mock).mockRejectedValue('String error');
+
+    await expect(
+      onRampStatus({
+        id: mockSessionId,
+        client: mockClient
+      })
+    ).rejects.toThrow(
+      `Failed to get onramp status for session ${mockSessionId}: Unknown error`
+    );
+  });
+
+  it('should pass correct parameters to Bridge.Onramp.status', async () => {
+    const mockResult: OnrampCreatedResult = {
+      status: 'CREATED',
+      transactions: [],
+      purchaseData: { testId: 'test' }
+    };
+
+    (Bridge.Onramp.status as jest.Mock).mockResolvedValue(mockResult);
+
+    const testId = 'custom-session-id';
+    const testClient = { clientId: 'custom-client' } as PannaClient;
+
+    await onRampStatus({
+      id: testId,
+      client: testClient
+    });
+
+    expect(Bridge.Onramp.status).toHaveBeenCalledTimes(1);
+    expect(Bridge.Onramp.status).toHaveBeenCalledWith({
+      id: testId,
+      client: testClient
+    });
+  });
+});

--- a/packages/panna-sdk/src/core/onramp/onramp.ts
+++ b/packages/panna-sdk/src/core/onramp/onramp.ts
@@ -1,0 +1,69 @@
+import { Bridge } from 'thirdweb';
+import type { OnrampStatusParams, OnrampStatusResult } from './types';
+
+/**
+ * Retrieves the status of an Onramp session created via prepareOnRamp
+ *
+ * The status will include any on-chain transactions that have occurred as a result
+ * of the onramp as well as any arbitrary purchaseData that was supplied when the
+ * onramp was prepared. This function allows you to track the progress of a fiat-to-crypto
+ * onramp transaction from creation through completion.
+ *
+ * @param params - Parameters for retrieving the onramp status
+ * @param params.id - The onramp session identifier (UUID returned from prepareOnRamp)
+ * @param params.client - The Panna client instance used for authentication
+ * @returns Promise resolving to the onramp status with transaction details and purchase data
+ * @throws Error if the session ID is invalid, client is unauthorized, or network request fails
+ *
+ * @example
+ * ```ts
+ * // Check the status of an onramp session
+ * const status = await onRampStatus({
+ *   id: "022218cc-96af-4291-b90c-dadcb47571ec",
+ *   client: pannaClient
+ * });
+ *
+ * // Handle different status types
+ * switch (status.status) {
+ *   case 'CREATED':
+ *     console.log('Onramp session created, waiting for payment');
+ *     // status.transactions: [] (empty)
+ *     // status.purchaseData: { sessionId: "abc", metadata: {...} }
+ *     break;
+ *
+ *   case 'PENDING':
+ *     console.log('Payment received, processing onramp...');
+ *     // status.transactions: [] (empty)
+ *     // status.purchaseData: { sessionId: "abc", amount: 100 }
+ *     break;
+ *
+ *   case 'COMPLETED':
+ *     console.log('Onramp completed successfully!');
+ *     console.log('Transactions:', status.transactions);
+ *     // status.transactions: [{ chainId: 1, transactionHash: "0x..." }, ...]
+ *     // status.purchaseData: { sessionId: "abc", completedAt: "2024-01-15T10:30:00Z" }
+ *     break;
+ * }
+ * ```
+ */
+export async function onRampStatus(
+  params: OnrampStatusParams
+): Promise<OnrampStatusResult> {
+  const { id, client } = params;
+
+  try {
+    const result = await Bridge.Onramp.status({
+      id,
+      client
+    });
+
+    return result as OnrampStatusResult;
+  } catch (error) {
+    // Re-throw with more context
+    throw new Error(
+      `Failed to get onramp status for session ${id}: ${
+        error instanceof Error ? error.message : 'Unknown error'
+      }`
+    );
+  }
+}

--- a/packages/panna-sdk/src/core/onramp/types.test.ts
+++ b/packages/panna-sdk/src/core/onramp/types.test.ts
@@ -1,0 +1,141 @@
+import type { PannaClient } from '../client';
+import type {
+  OnrampStatus,
+  OnrampTransaction,
+  OnrampPurchaseData,
+  OnrampStatusParams,
+  OnrampStatusResult,
+  OnrampCreatedResult,
+  OnrampPendingResult,
+  OnrampCompletedResult
+} from './types';
+
+describe('Onramp Types', () => {
+  it('should allow valid OnrampStatus values', () => {
+    const createdStatus: OnrampStatus = 'CREATED';
+    const pendingStatus: OnrampStatus = 'PENDING';
+    const completedStatus: OnrampStatus = 'COMPLETED';
+
+    expect(createdStatus).toBe('CREATED');
+    expect(pendingStatus).toBe('PENDING');
+    expect(completedStatus).toBe('COMPLETED');
+  });
+
+  it('should enforce OnrampTransaction structure', () => {
+    const transaction: OnrampTransaction = {
+      chainId: 1,
+      transactionHash: '0xabc123...'
+    };
+
+    expect(transaction.chainId).toBe(1);
+    expect(transaction.transactionHash).toBe('0xabc123...');
+  });
+
+  it('should allow flexible OnrampPurchaseData', () => {
+    const purchaseData: OnrampPurchaseData = {
+      sessionId: 'session-123',
+      amount: '100',
+      currency: 'USD',
+      customField: { nested: true },
+      metadata: ['tag1', 'tag2']
+    };
+
+    expect(purchaseData.sessionId).toBe('session-123');
+    expect(purchaseData.amount).toBe('100');
+    expect(purchaseData.currency).toBe('USD');
+    expect(purchaseData.customField).toEqual({ nested: true });
+    expect(purchaseData.metadata).toEqual(['tag1', 'tag2']);
+  });
+
+  it('should enforce OnrampStatusParams structure', () => {
+    const mockClient = { clientId: 'test' } as PannaClient;
+    const params: OnrampStatusParams = {
+      id: 'session-123',
+      client: mockClient
+    };
+
+    expect(params.id).toBe('session-123');
+    expect(params.client).toBe(mockClient);
+  });
+
+  it('should correctly type CREATED status result', () => {
+    const createdResult: OnrampCreatedResult = {
+      status: 'CREATED',
+      transactions: [],
+      purchaseData: { testId: 'test' }
+    };
+
+    expect(createdResult.status).toBe('CREATED');
+    expect(createdResult.transactions).toHaveLength(0);
+
+    // TypeScript should enforce empty transactions array
+    const isCorrectType: OnrampStatusResult = createdResult;
+    expect(isCorrectType).toBeDefined();
+  });
+
+  it('should correctly type PENDING status result', () => {
+    const pendingResult: OnrampPendingResult = {
+      status: 'PENDING',
+      transactions: [],
+      purchaseData: { testId: 'test' }
+    };
+
+    expect(pendingResult.status).toBe('PENDING');
+    expect(pendingResult.transactions).toHaveLength(0);
+
+    const isCorrectType: OnrampStatusResult = pendingResult;
+    expect(isCorrectType).toBeDefined();
+  });
+
+  it('should correctly type COMPLETED status result', () => {
+    const completedResult: OnrampCompletedResult = {
+      status: 'COMPLETED',
+      transactions: [
+        { chainId: 1, transactionHash: '0x123' },
+        { chainId: 56, transactionHash: '0x456' }
+      ],
+      purchaseData: { testId: 'test' }
+    };
+
+    expect(completedResult.status).toBe('COMPLETED');
+    expect(completedResult.transactions).toHaveLength(2);
+
+    const isCorrectType: OnrampStatusResult = completedResult;
+    expect(isCorrectType).toBeDefined();
+  });
+
+  it('should allow type narrowing on OnrampStatusResult', () => {
+    // Test type narrowing with a function that handles different statuses
+    function handleOnrampStatus(result: OnrampStatusResult) {
+      switch (result.status) {
+        case 'COMPLETED':
+          // TypeScript knows transactions can have items for completed status
+          return result.transactions.length;
+        case 'CREATED':
+        case 'PENDING':
+          // TypeScript knows transactions is empty for these statuses
+          return result.transactions.length === 0;
+        default: {
+          // Exhaustiveness check
+          const _exhaustiveCheck: never = result;
+          return _exhaustiveCheck;
+        }
+      }
+    }
+
+    const completedResult: OnrampStatusResult = {
+      status: 'COMPLETED',
+      transactions: [{ chainId: 1, transactionHash: '0x123' }],
+      purchaseData: { testId: 'test' }
+    };
+
+    const createdResult: OnrampStatusResult = {
+      status: 'CREATED',
+      transactions: [],
+      purchaseData: { testId: 'test' }
+    };
+
+    expect(handleOnrampStatus(completedResult)).toBe(1);
+    expect(handleOnrampStatus(createdResult)).toBe(true);
+  });
+});

--- a/packages/panna-sdk/src/core/onramp/types.ts
+++ b/packages/panna-sdk/src/core/onramp/types.ts
@@ -1,0 +1,50 @@
+import type { PannaClient } from '../client';
+
+// Onramp transaction status types
+export type OnrampStatus = 'CREATED' | 'PENDING' | 'COMPLETED';
+
+// Transaction details for completed onramps
+export interface OnrampTransaction {
+  chainId: number;
+  transactionHash: string;
+}
+
+// Purchase data included with onramp status
+export type OnrampPurchaseData = Record<string, unknown>;
+
+// Parameters for getting onramp status
+export interface OnrampStatusParams {
+  id: string; // Onramp session identifier
+  client: PannaClient;
+}
+
+// Base result structure for all statuses
+interface BaseOnrampStatusResult {
+  status: OnrampStatus;
+  transactions: OnrampTransaction[];
+  purchaseData: OnrampPurchaseData;
+}
+
+// Created status result
+export interface OnrampCreatedResult extends BaseOnrampStatusResult {
+  status: 'CREATED';
+  transactions: []; // Always empty for created status
+}
+
+// Pending status result
+export interface OnrampPendingResult extends BaseOnrampStatusResult {
+  status: 'PENDING';
+  transactions: []; // Always empty for pending status
+}
+
+// Completed status result
+export interface OnrampCompletedResult extends BaseOnrampStatusResult {
+  status: 'COMPLETED';
+  transactions: OnrampTransaction[]; // Contains transaction details
+}
+
+// Union type for all possible status results
+export type OnrampStatusResult =
+  | OnrampCreatedResult
+  | OnrampPendingResult
+  | OnrampCompletedResult;

--- a/packages/panna-sdk/src/index.ts
+++ b/packages/panna-sdk/src/index.ts
@@ -55,6 +55,17 @@ export {
   type GetFiatPriceParams,
   type GetFiatPriceResult,
   type FiatCurrency,
+  // Onramp functions
+  onRampStatus,
+  // Onramp types
+  type OnrampStatus,
+  type OnrampTransaction,
+  type OnrampPurchaseData,
+  type OnrampStatusParams,
+  type OnrampStatusResult,
+  type OnrampCreatedResult,
+  type OnrampPendingResult,
+  type OnrampCompletedResult,
   // Constants
   DEFAULT_CURRENCY,
   DEFAULT_CHAIN,


### PR DESCRIPTION
### What was the problem?

This PR resolves LISK-2252.

### How was it solved?

This PR exposes the `onRampStatus` function that allows developers to track the status of onramp sessions from creation through completion. The function wraps Thirdweb's `Bridge.Onramp.status` API and provides comprehensive types for all status states (`CREATED`, `PENDING`, `COMPLETED`) along with transaction details and flexible purchase data structures.

### How was it tested?

New unit tests were written.