### PR TITLE
Expose onRampPrepare

### DIFF
--- a/packages/panna-sdk/src/core/onramp/index.ts
+++ b/packages/panna-sdk/src/core/onramp/index.ts
@@ -10,5 +10,9 @@ export type {
   OnrampStatusResult,
   OnrampCreatedResult,
   OnrampPendingResult,
-  OnrampCompletedResult
+  OnrampCompletedResult,
+  OnRampProvider,
+  OnrampPrepareResult,
+  OnRampIntent,
+  OnrampPrepareParams
 } from './types';

--- a/packages/panna-sdk/src/core/onramp/types.ts
+++ b/packages/panna-sdk/src/core/onramp/types.ts
@@ -47,3 +47,39 @@ export type OnrampStatusResult =
   | OnrampCreatedResult
   | OnrampPendingResult
   | OnrampCompletedResult;
+
+// Onramp providers list
+export type OnRampProvider = 'stripe' | 'coinbase' | 'transak';
+
+// Parameters for preparing an onramp
+export interface OnrampPrepareParams {
+  client: PannaClient;
+  onRampProvider: OnRampProvider;
+  chainId?: number;
+  tokenAddress: string;
+  receiver: string;
+  amount: string;
+  purchaseData?: OnrampPurchaseData;
+  country: string;
+}
+
+// OnRamp intent to hold provider info
+export interface OnRampIntent {
+  onRampProvider: OnRampProvider;
+  chainId: number;
+  tokenAddress: string;
+  receiver: string;
+  amount: string;
+}
+
+// Result structure for prepared onramps
+export interface OnrampPrepareResult {
+  id: string;
+  link: string;
+  currency: string;
+  currencyAmount: string;
+  destinationAmount: string;
+  timestamp?: number;
+  expiration?: number;
+  intent?: OnRampIntent;
+}

--- a/packages/panna-sdk/src/index.ts
+++ b/packages/panna-sdk/src/index.ts
@@ -66,6 +66,10 @@ export {
   type OnrampCreatedResult,
   type OnrampPendingResult,
   type OnrampCompletedResult,
+  type OnRampProvider,
+  type OnrampPrepareResult,
+  type OnRampIntent,
+  type OnrampPrepareParams,
   // Constants
   DEFAULT_CURRENCY,
   DEFAULT_CHAIN,


### PR DESCRIPTION
## Summary

Expose onRampPrepare function

## Rationale

In order to perform on-ramping, we need to expose onRampPrepare function that can take provider and return details like redirection url, session-id, etc

## Changes

- Add onRampPrepare function and related interface
- Add tests

## Impact

No impact on any other part

## Testing

- Unit tests

## Screenshots/Video

Include screenshots or video demonstrating the new feature, if applicable.

## Checklist

- [ ] Code follows the project's coding standards

- [ ] Unit tests covering the new feature have been added

- [ ] All existing tests pass

- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

Any additional information or context relevant to this PR.
