### PR TITLE
Expose transaction prepare core functions

### DIFF
--- a/packages/panna-sdk/src/core/index.ts
+++ b/packages/panna-sdk/src/core/index.ts
@@ -4,3 +4,4 @@ export * from './wallet';
 export * from './utils';
 export * from './defaults';
 export * from './onramp';
+export * from './transaction';

--- a/packages/panna-sdk/src/core/transaction/index.ts
+++ b/packages/panna-sdk/src/core/transaction/index.ts
@@ -1,0 +1,2 @@
+export * from './transaction';
+export * from './types';

--- a/packages/panna-sdk/src/core/transaction/transaction.test.ts
+++ b/packages/panna-sdk/src/core/transaction/transaction.test.ts
@@ -1,0 +1,335 @@
+import * as thirdweb from 'thirdweb';
+import type { Chain } from '../chains/types';
+import type { PannaClient } from '../client';
+import {
+  prepareTransaction,
+  prepareContractCall,
+  getContract
+} from './transaction';
+
+// Mock thirdweb module
+jest.mock('thirdweb', () => ({
+  prepareTransaction: jest.fn(),
+  prepareContractCall: jest.fn(),
+  getContract: jest.fn()
+}));
+
+describe('Transaction Functions', () => {
+  const mockClient = { clientId: 'test-client' } as PannaClient;
+  const mockChain = { id: 1, name: 'Ethereum' } as Chain;
+  const mockContract = {
+    client: mockClient,
+    address: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+    chain: mockChain
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('prepareTransaction', () => {
+    it('should prepare a basic transaction', () => {
+      const mockResult = {
+        to: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        value: BigInt('1000000000000000000')
+      };
+
+      (thirdweb.prepareTransaction as jest.Mock).mockReturnValue(mockResult);
+
+      const params = {
+        client: mockClient,
+        chain: mockChain,
+        to: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        value: BigInt('1000000000000000000')
+      };
+
+      const result = prepareTransaction(params);
+
+      expect(thirdweb.prepareTransaction).toHaveBeenCalledWith({
+        client: mockClient,
+        chain: mockChain,
+        to: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        value: BigInt('1000000000000000000')
+      });
+      expect(result).toEqual(mockResult);
+    });
+
+    it('should prepare a transaction with custom data', () => {
+      const mockResult = {
+        to: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        data: '0x123456'
+      };
+
+      (thirdweb.prepareTransaction as jest.Mock).mockReturnValue(mockResult);
+
+      const params = {
+        client: mockClient,
+        chain: mockChain,
+        to: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        data: '0x123456'
+      };
+
+      const result = prepareTransaction(params);
+
+      expect(thirdweb.prepareTransaction).toHaveBeenCalledWith({
+        client: mockClient,
+        chain: mockChain,
+        to: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        data: '0x123456'
+      });
+      expect(result).toEqual(mockResult);
+    });
+
+    it('should handle minimal required parameters', () => {
+      const mockResult = {
+        to: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e'
+      };
+
+      (thirdweb.prepareTransaction as jest.Mock).mockReturnValue(mockResult);
+
+      const params = {
+        client: mockClient,
+        chain: mockChain,
+        to: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e'
+      };
+
+      const result = prepareTransaction(params);
+
+      expect(thirdweb.prepareTransaction).toHaveBeenCalledWith({
+        client: mockClient,
+        chain: mockChain,
+        to: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e'
+      });
+      expect(result).toEqual(mockResult);
+    });
+
+    it('should prepare a transaction with gas parameters', () => {
+      const mockResult = {
+        to: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        value: BigInt('1000000000000000000'),
+        gasPrice: BigInt('20000000000'),
+        gas: BigInt('21000')
+      };
+
+      (thirdweb.prepareTransaction as jest.Mock).mockReturnValue(mockResult);
+
+      const params = {
+        client: mockClient,
+        chain: mockChain,
+        to: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        value: BigInt('1000000000000000000'),
+        gasPrice: BigInt('20000000000'),
+        gas: BigInt('21000'),
+        nonce: 42
+      };
+
+      const result = prepareTransaction(params);
+
+      expect(thirdweb.prepareTransaction).toHaveBeenCalledWith({
+        client: mockClient,
+        chain: mockChain,
+        to: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        value: BigInt('1000000000000000000'),
+        gasPrice: BigInt('20000000000'),
+        gas: BigInt('21000'),
+        nonce: 42
+      });
+      expect(result).toEqual(mockResult);
+    });
+  });
+
+  describe('prepareContractCall', () => {
+    it('should prepare a basic contract call', () => {
+      const mockDataFunction = jest.fn().mockResolvedValue('0xa9059cbb');
+      const mockResult = {
+        to: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        data: mockDataFunction
+      };
+
+      (thirdweb.prepareContractCall as jest.Mock).mockReturnValue(mockResult);
+
+      const params = {
+        contract: mockContract,
+        method: 'function transfer(address to, uint256 amount)',
+        params: ['0x123456789', BigInt('1000000000000000000')]
+      };
+
+      const result = prepareContractCall(params);
+
+      expect(thirdweb.prepareContractCall).toHaveBeenCalledWith({
+        contract: mockContract,
+        method: 'function transfer(address to, uint256 amount)',
+        params: ['0x123456789', BigInt('1000000000000000000')]
+      });
+      expect(result).toEqual({
+        to: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        data: mockDataFunction
+      });
+    });
+
+    it('should prepare a payable contract call', () => {
+      const mockDataFunction = jest.fn().mockResolvedValue('0x40c10f19');
+      const mockResult = {
+        to: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        data: mockDataFunction,
+        value: BigInt('100000000000000000')
+      };
+
+      (thirdweb.prepareContractCall as jest.Mock).mockReturnValue(mockResult);
+
+      const params = {
+        contract: mockContract,
+        method: 'function mint(address to)',
+        params: ['0x123456789'],
+        value: BigInt('100000000000000000')
+      };
+
+      const result = prepareContractCall(params);
+
+      expect(thirdweb.prepareContractCall).toHaveBeenCalledWith({
+        contract: mockContract,
+        method: 'function mint(address to)',
+        params: ['0x123456789'],
+        value: BigInt('100000000000000000')
+      });
+      expect(result).toEqual({
+        to: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        data: mockDataFunction,
+        value: BigInt('100000000000000000')
+      });
+    });
+
+    it('should prepare a contract call without parameters', () => {
+      const mockDataFunction = jest.fn().mockResolvedValue('0x18160ddd');
+      const mockResult = {
+        to: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        data: mockDataFunction
+      };
+
+      (thirdweb.prepareContractCall as jest.Mock).mockReturnValue(mockResult);
+
+      const params = {
+        contract: mockContract,
+        method: 'function totalSupply()'
+      };
+
+      const result = prepareContractCall(params);
+
+      expect(thirdweb.prepareContractCall).toHaveBeenCalledWith({
+        contract: mockContract,
+        method: 'function totalSupply()'
+      });
+      expect(result).toEqual({
+        to: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        data: mockDataFunction
+      });
+    });
+
+    it('should handle ABI function objects', () => {
+      const mockAbiFunction = {
+        type: 'function',
+        name: 'transfer',
+        inputs: [
+          { type: 'address', name: 'to' },
+          { type: 'uint256', name: 'amount' }
+        ],
+        outputs: [],
+        stateMutability: 'nonpayable'
+      };
+
+      const mockDataFunction = jest.fn().mockResolvedValue('0xa9059cbb');
+      const mockResult = {
+        to: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        data: mockDataFunction
+      };
+
+      (thirdweb.prepareContractCall as jest.Mock).mockReturnValue(mockResult);
+
+      const params = {
+        contract: mockContract,
+        method: mockAbiFunction,
+        params: ['0x123456789', BigInt('1000000000000000000')]
+      };
+
+      const result = prepareContractCall(params);
+
+      expect(thirdweb.prepareContractCall).toHaveBeenCalledWith({
+        contract: mockContract,
+        method: mockAbiFunction,
+        params: ['0x123456789', BigInt('1000000000000000000')]
+      });
+      expect(result).toEqual({
+        to: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        data: mockDataFunction
+      });
+    });
+  });
+
+  describe('getContract', () => {
+    it('should get a contract instance with minimal parameters', () => {
+      const mockResult = {
+        client: mockClient,
+        address: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        chain: mockChain
+      };
+
+      (thirdweb.getContract as jest.Mock).mockReturnValue(mockResult);
+
+      const params = {
+        client: mockClient,
+        address: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        chain: mockChain
+      };
+
+      const result = getContract(params);
+
+      expect(thirdweb.getContract).toHaveBeenCalledWith({
+        client: mockClient,
+        address: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        chain: mockChain
+      });
+      expect(result).toEqual(mockResult);
+    });
+
+    it('should get a contract instance with ABI', () => {
+      const mockAbi = [
+        {
+          type: 'function' as const,
+          name: 'transfer',
+          inputs: [
+            { type: 'address', name: 'to' },
+            { type: 'uint256', name: 'amount' }
+          ],
+          outputs: [],
+          stateMutability: 'nonpayable' as const
+        }
+      ];
+
+      const mockResult = {
+        client: mockClient,
+        address: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        abi: mockAbi,
+        chain: mockChain
+      };
+
+      (thirdweb.getContract as jest.Mock).mockReturnValue(mockResult);
+
+      const params = {
+        client: mockClient,
+        address: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        abi: mockAbi,
+        chain: mockChain
+      };
+
+      const result = getContract(params);
+
+      expect(thirdweb.getContract).toHaveBeenCalledWith({
+        client: mockClient,
+        address: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        abi: mockAbi,
+        chain: mockChain
+      });
+      expect(result).toEqual(mockResult);
+    });
+  });
+});

--- a/packages/panna-sdk/src/core/transaction/transaction.ts
+++ b/packages/panna-sdk/src/core/transaction/transaction.ts
@@ -1,0 +1,238 @@
+import {
+  prepareContractCall as thirdwebPrepareContractCall,
+  prepareTransaction as thirdwebPrepareTransaction,
+  getContract as thirdwebGetContract
+} from 'thirdweb';
+import type {
+  PrepareTransactionParams,
+  PrepareTransactionResult,
+  PrepareContractCallParams,
+  PrepareContractCallResult,
+  GetContractParams,
+  GetContractResult
+} from './types';
+
+/**
+ * Prepare a raw transaction for execution
+ *
+ * This function creates a transaction object that can be used to send native tokens,
+ * execute arbitrary contract interactions, or deploy contracts. The transaction is
+ * prepared synchronously without making network requests.
+ *
+ * @param params - Parameters for preparing the transaction
+ * @param params.client - The Panna client instance
+ * @param params.chain - The chain to execute on
+ * @param params.to - The recipient address (optional for contract deployments)
+ * @param params.value - The value to send (in wei)
+ * @param params.data - The transaction data
+ * @param params.gas - Gas limit for the transaction
+ * @param params.gasPrice - Gas price for legacy transactions
+ * @param params.maxFeePerGas - Maximum fee per gas for EIP-1559 transactions
+ * @param params.maxPriorityFeePerGas - Maximum priority fee per gas for EIP-1559
+ * @param params.nonce - Transaction nonce
+ * @param params.extraGas - Additional gas to add to the estimated gas
+ * @param params.accessList - Access list for EIP-2930 transactions
+ * @returns Prepared transaction object
+ *
+ * @example
+ * ```typescript
+ * import { prepareTransaction, toWei, lisk } from 'panna-sdk';
+ *
+ * // Prepare a simple ETH transfer
+ * const transaction = prepareTransaction({
+ *   client: pannaClient,
+ *   chain: lisk,
+ *   to: "0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e",
+ *   value: toWei("1") // 1 ETH
+ * });
+ *
+ * // Prepare a transaction with gas settings
+ * const txWithGas = prepareTransaction({
+ *   client: pannaClient,
+ *   chain: lisk,
+ *   to: "0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e",
+ *   value: toWei("0.5"),
+ *   gasPrice: BigInt(20000000000) // 20 gwei
+ * });
+ *
+ * // Prepare a contract deployment (no `to` address)
+ * const deployTx = prepareTransaction({
+ *   client: pannaClient,
+ *   chain: lisk,
+ *   data: "0x608060405234801561001057600080fd5b50...", // contract bytecode
+ *   value: 0n
+ * });
+ * ```
+ */
+export function prepareTransaction(
+  params: PrepareTransactionParams
+): PrepareTransactionResult {
+  const {
+    client,
+    chain,
+    to,
+    value,
+    data,
+    gas,
+    gasPrice,
+    maxFeePerGas,
+    maxPriorityFeePerGas,
+    nonce,
+    extraGas,
+    accessList
+  } = params;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const prepareParams: any = {
+    client,
+    chain,
+    ...(to !== undefined && { to }),
+    ...(value !== undefined && { value }),
+    ...(data !== undefined && { data }),
+    ...(gas !== undefined && { gas }),
+    ...(gasPrice !== undefined && { gasPrice }),
+    ...(maxFeePerGas !== undefined && { maxFeePerGas }),
+    ...(maxPriorityFeePerGas !== undefined && { maxPriorityFeePerGas }),
+    ...(nonce !== undefined && { nonce }),
+    ...(extraGas !== undefined && { extraGas }),
+    ...(accessList !== undefined && { accessList })
+  };
+
+  return thirdwebPrepareTransaction(prepareParams) as PrepareTransactionResult;
+}
+
+/**
+ * Prepare a contract method call for execution
+ *
+ * This function creates a transaction object for calling a specific method on a smart contract.
+ * It supports both string method signatures and ABI function objects, providing type safety
+ * and parameter validation.
+ *
+ * @param params - Parameters for preparing the contract call
+ * @param params.contract - The contract instance
+ * @param params.method - The method signature or ABI function
+ * @param params.params - The parameters for the method call
+ * @param params.value - The value to send with the transaction (in wei)
+ * @param params.gas - Gas limit for the transaction
+ * @param params.gasPrice - Gas price for legacy transactions
+ * @param params.maxFeePerGas - Maximum fee per gas for EIP-1559 transactions
+ * @param params.maxPriorityFeePerGas - Maximum priority fee per gas for EIP-1559
+ * @param params.nonce - Transaction nonce
+ * @param params.extraGas - Additional gas to add to the estimated gas
+ * @param params.accessList - Access list for EIP-2930 transactions
+ * @returns Prepared contract call transaction
+ *
+ * @example
+ * ```typescript
+ * import { prepareContractCall, getContract, toWei, lisk } from 'panna-sdk';
+ *
+ * // Get a contract instance
+ * const contract = getContract({
+ *   client: pannaClient,
+ *   address: "0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e",
+ *   chain: lisk
+ * });
+ *
+ * // Prepare a contract call with method signature
+ * const transaction = prepareContractCall({
+ *   contract,
+ *   method: "function transfer(address to, uint256 amount)",
+ *   params: ["0x123...", toWei("100")]
+ * });
+ *
+ * // Prepare a payable contract call
+ * const payableCall = prepareContractCall({
+ *   contract,
+ *   method: "function mint(address to)",
+ *   params: ["0x123..."],
+ *   value: toWei("0.1") // 0.1 ETH
+ * });
+ * ```
+ */
+export function prepareContractCall(
+  params: PrepareContractCallParams
+): PrepareContractCallResult {
+  const {
+    contract,
+    method,
+    params: methodParams,
+    value,
+    gas,
+    gasPrice,
+    maxFeePerGas,
+    maxPriorityFeePerGas,
+    nonce,
+    extraGas,
+    accessList
+  } = params;
+
+  const contractWithTypedAddress = {
+    ...contract,
+    address: contract.address
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const callParams: any = {
+    contract: contractWithTypedAddress,
+    method,
+    params: methodParams,
+    ...(value !== undefined && { value }),
+    ...(gas !== undefined && { gas }),
+    ...(gasPrice !== undefined && { gasPrice }),
+    ...(maxFeePerGas !== undefined && { maxFeePerGas }),
+    ...(maxPriorityFeePerGas !== undefined && { maxPriorityFeePerGas }),
+    ...(nonce !== undefined && { nonce }),
+    ...(extraGas !== undefined && { extraGas }),
+    ...(accessList !== undefined && { accessList })
+  };
+
+  return thirdwebPrepareContractCall(callParams) as PrepareContractCallResult;
+}
+
+/**
+ * Get a contract instance for interaction
+ *
+ * This function creates a contract instance that can be used to prepare contract calls.
+ * It provides type-safe access to contract methods when an ABI is provided, and enables
+ * autocompletion and validation of method calls.
+ *
+ * @param params - Parameters for getting the contract
+ * @param params.client - The Panna client instance
+ * @param params.address - The contract address
+ * @param params.abi - The contract ABI (optional for basic interactions)
+ * @param params.chain - The chain the contract is deployed on
+ * @returns Contract instance ready for interaction
+ *
+ * @example
+ * ```typescript
+ * import { getContract, lisk } from 'panna-sdk';
+ *
+ * // Get a contract instance without ABI
+ * const contract = getContract({
+ *   client: pannaClient,
+ *   address: "0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e",
+ *   chain: lisk
+ * });
+ *
+ * // Get a contract instance with full ABI (erc20Abi should be defined in your code)
+ * const erc20Contract = getContract({
+ *   client: pannaClient,
+ *   address: "0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e",
+ *   abi: erc20Abi, // Define this ABI in your code or import from your contract definitions
+ *   chain: lisk
+ * });
+ * ```
+ */
+export function getContract(params: GetContractParams): GetContractResult {
+  const { client, address, abi, chain } = params;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const contractParams: any = {
+    client,
+    address: address,
+    chain,
+    ...(abi !== undefined && { abi })
+  };
+
+  return thirdwebGetContract(contractParams) as GetContractResult;
+}

--- a/packages/panna-sdk/src/core/transaction/types.test.ts
+++ b/packages/panna-sdk/src/core/transaction/types.test.ts
@@ -1,0 +1,339 @@
+import type { Chain } from '../chains/types';
+import type { PannaClient } from '../client';
+import type {
+  PrepareTransactionParams,
+  PrepareTransactionResult,
+  PrepareContractCallParams,
+  PrepareContractCallResult,
+  GetContractParams,
+  GetContractResult
+} from './types';
+
+describe('Transaction Types', () => {
+  const mockClient = { clientId: 'test-client' } as PannaClient;
+  const mockChain = { id: 1, name: 'Ethereum' } as Chain;
+  const mockContract = {
+    client: mockClient,
+    address: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+    chain: mockChain
+  };
+
+  describe('PrepareTransactionParams', () => {
+    it('should accept valid minimal parameters', () => {
+      const params: PrepareTransactionParams = {
+        client: mockClient,
+        chain: mockChain,
+        to: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e'
+      };
+
+      expect(params).toBeDefined();
+      expect(params.client).toBe(mockClient);
+      expect(params.chain).toBe(mockChain);
+      expect(params.to).toBe('0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e');
+    });
+
+    it('should accept all optional parameters', () => {
+      const params: PrepareTransactionParams = {
+        client: mockClient,
+        chain: mockChain,
+        to: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        value: BigInt('1000000000000000000'),
+        data: '0x123456',
+        gas: BigInt('21000'),
+        gasPrice: BigInt('20000000000'),
+        maxFeePerGas: BigInt('30000000000'),
+        maxPriorityFeePerGas: BigInt('2000000000'),
+        nonce: 42,
+        extraGas: BigInt('5000'),
+        accessList: [
+          {
+            address: '0x123456789',
+            storageKeys: ['0xabc', '0xdef']
+          }
+        ]
+      };
+
+      expect(params).toBeDefined();
+      expect(params.chain).toBe(mockChain);
+      expect(params.value).toBe(BigInt('1000000000000000000'));
+      expect(params.data).toBe('0x123456');
+      expect(params.gas).toBe(BigInt('21000'));
+      expect(params.gasPrice).toBe(BigInt('20000000000'));
+      expect(params.maxFeePerGas).toBe(BigInt('30000000000'));
+      expect(params.maxPriorityFeePerGas).toBe(BigInt('2000000000'));
+      expect(params.nonce).toBe(42);
+      expect(params.extraGas).toBe(BigInt('5000'));
+      expect(params.accessList).toEqual([
+        {
+          address: '0x123456789',
+          storageKeys: ['0xabc', '0xdef']
+        }
+      ]);
+    });
+  });
+
+  describe('PrepareTransactionResult', () => {
+    it('should match expected structure', () => {
+      const result: PrepareTransactionResult = {
+        client: mockClient,
+        chain: mockChain,
+        to: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        value: BigInt('1000000000000000000'),
+        data: '0x123456',
+        gasPrice: BigInt('20000000000')
+      };
+
+      expect(result).toBeDefined();
+      expect(result.client).toBe(mockClient);
+      expect(result.chain).toBe(mockChain);
+      expect(result.to).toBe('0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e');
+      expect(result.value).toBe(BigInt('1000000000000000000'));
+      expect(result.data).toBe('0x123456');
+      expect(result.gasPrice).toBe(BigInt('20000000000'));
+    });
+
+    it('should handle minimal result', () => {
+      const result: PrepareTransactionResult = {
+        client: mockClient,
+        chain: mockChain,
+        to: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e'
+      };
+
+      expect(result.client).toBe(mockClient);
+      expect(result.chain).toBe(mockChain);
+      expect(result.to).toBe('0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e');
+      expect(result.value).toBeUndefined();
+      expect(result.data).toBeUndefined();
+      expect(result.gasPrice).toBeUndefined();
+    });
+  });
+
+  describe('PrepareContractCallParams', () => {
+    it('should accept valid minimal parameters', () => {
+      const params: PrepareContractCallParams = {
+        contract: mockContract,
+        method: 'function totalSupply()'
+      };
+
+      expect(params).toBeDefined();
+      expect(params.contract).toBe(mockContract);
+      expect(params.method).toBe('function totalSupply()');
+    });
+
+    it('should accept gas parameters', () => {
+      const params: PrepareContractCallParams = {
+        contract: mockContract,
+        method: 'function transfer(address to, uint256 amount)',
+        params: ['0x123456789', BigInt('1000000000000000000')],
+        value: BigInt('100000000000000000'),
+        gas: BigInt('21000'),
+        gasPrice: BigInt('20000000000'),
+        maxFeePerGas: BigInt('30000000000'),
+        maxPriorityFeePerGas: BigInt('2000000000'),
+        nonce: 42
+      };
+
+      expect(params.gas).toBe(BigInt('21000'));
+      expect(params.gasPrice).toBe(BigInt('20000000000'));
+      expect(params.maxFeePerGas).toBe(BigInt('30000000000'));
+      expect(params.nonce).toBe(42);
+    });
+
+    it('should accept method with parameters', () => {
+      const params: PrepareContractCallParams = {
+        contract: mockContract,
+        method: 'function transfer(address to, uint256 amount)',
+        params: ['0x123456789', BigInt('1000000000000000000')]
+      };
+
+      expect(params.params).toEqual([
+        '0x123456789',
+        BigInt('1000000000000000000')
+      ]);
+    });
+
+    it('should accept value for payable methods', () => {
+      const params: PrepareContractCallParams = {
+        contract: mockContract,
+        method: 'function mint(address to)',
+        params: ['0x123456789'],
+        value: BigInt('100000000000000000')
+      };
+
+      expect(params.value).toBe(BigInt('100000000000000000'));
+    });
+
+    it('should accept ABI function object', () => {
+      const abiFunction = {
+        type: 'function' as const,
+        name: 'transfer',
+        inputs: [
+          { type: 'address', name: 'to' },
+          { type: 'uint256', name: 'amount' }
+        ]
+      };
+
+      const params: PrepareContractCallParams = {
+        contract: mockContract,
+        method: abiFunction,
+        params: ['0x123456789', BigInt('1000000000000000000')]
+      };
+
+      expect(params.method).toBe(abiFunction);
+    });
+  });
+
+  describe('PrepareContractCallResult', () => {
+    it('should match expected structure', () => {
+      const mockDataFunction = async () =>
+        '0xa9059cbb000000000000000000000000123456789000000000000000000000000000000000000000000000000000000000000000000000000000000000000de0b6b3a7640000';
+
+      const result: PrepareContractCallResult = {
+        to: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        data: mockDataFunction,
+        value: BigInt('100000000000000000'),
+        chain: mockChain
+      };
+
+      expect(result).toBeDefined();
+      expect(result.to).toBe('0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e');
+      expect(typeof result.data).toBe('function');
+      expect(result.value).toBe(BigInt('100000000000000000'));
+      expect(result.chain).toBe(mockChain);
+    });
+
+    it('should handle minimal result', () => {
+      const mockDataFunction = async () => '0x18160ddd';
+
+      const result: PrepareContractCallResult = {
+        to: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        data: mockDataFunction
+      };
+
+      expect(result.to).toBe('0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e');
+      expect(typeof result.data).toBe('function');
+      expect(result.value).toBeUndefined();
+      expect(result.chain).toBeUndefined();
+    });
+  });
+
+  describe('GetContractParams', () => {
+    it('should accept valid minimal parameters', () => {
+      const params: GetContractParams = {
+        client: mockClient,
+        address: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        chain: mockChain
+      };
+
+      expect(params).toBeDefined();
+      expect(params.client).toBe(mockClient);
+      expect(params.address).toBe('0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e');
+      expect(params.chain).toBe(mockChain);
+    });
+
+    it('should accept all optional parameters', () => {
+      const mockAbi = [
+        {
+          type: 'function' as const,
+          name: 'transfer',
+          inputs: [
+            { type: 'address', name: 'to' },
+            { type: 'uint256', name: 'amount' }
+          ],
+          outputs: [],
+          stateMutability: 'nonpayable' as const
+        }
+      ];
+
+      const params: GetContractParams = {
+        client: mockClient,
+        address: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        chain: mockChain,
+        abi: mockAbi
+      };
+
+      expect(params.abi).toBe(mockAbi);
+      expect(params.chain).toBe(mockChain);
+    });
+  });
+
+  describe('GetContractResult', () => {
+    it('should have correct structure', () => {
+      const result: GetContractResult = {
+        client: mockClient,
+        address: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        chain: mockChain
+      };
+
+      expect(result).toBeDefined();
+      expect(result.client).toBe(mockClient);
+      expect(result.address).toBe('0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e');
+      expect(result.chain).toBe(mockChain);
+    });
+
+    it('should handle optional ABI', () => {
+      const mockAbi = [
+        {
+          type: 'function' as const,
+          name: 'transfer',
+          inputs: [
+            { type: 'address', name: 'to' },
+            { type: 'uint256', name: 'amount' }
+          ],
+          outputs: [],
+          stateMutability: 'nonpayable' as const
+        }
+      ];
+
+      const result: GetContractResult = {
+        client: mockClient,
+        address: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        abi: mockAbi,
+        chain: mockChain
+      };
+
+      expect(result.abi).toBe(mockAbi);
+    });
+  });
+
+  describe('Type Exports', () => {
+    it('should export all parameter types', () => {
+      // This test ensures all types are properly exported and can be imported
+      const testTypes = {
+        PrepareTransactionParams: {} as PrepareTransactionParams,
+        PrepareTransactionResult: {} as PrepareTransactionResult,
+        PrepareContractCallParams: {} as PrepareContractCallParams,
+        PrepareContractCallResult: {} as PrepareContractCallResult,
+        GetContractParams: {} as GetContractParams,
+        GetContractResult: {} as GetContractResult
+      };
+
+      expect(testTypes).toBeDefined();
+    });
+  });
+
+  describe('Type Compatibility', () => {
+    it('should be compatible with thirdweb types', () => {
+      // Test that our types are compatible with thirdweb types
+      const mockThirdwebParams = {
+        client: mockClient,
+        chain: mockChain,
+        to: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e',
+        value: BigInt('1000000000000000000'),
+        gasPrice: BigInt('20000000000')
+      };
+
+      // Should be assignable to our PrepareTransactionParams
+      const ourParams: PrepareTransactionParams = mockThirdwebParams;
+      expect(ourParams).toBeDefined();
+    });
+
+    it('should handle bigint values correctly', () => {
+      const bigintValue: PrepareTransactionParams['value'] = BigInt(
+        '1000000000000000000'
+      );
+
+      expect(typeof bigintValue).toBe('bigint');
+    });
+  });
+});

--- a/packages/panna-sdk/src/core/transaction/types.ts
+++ b/packages/panna-sdk/src/core/transaction/types.ts
@@ -1,0 +1,166 @@
+import type { Abi } from 'thirdweb/utils';
+import type { Chain } from '../chains/types';
+import type { PannaClient } from '../client';
+
+/**
+ * Parameters for preparing a raw transaction
+ *
+ * Note: The `to` field is optional to support:
+ * - Contract deployment transactions (no recipient)
+ * - Contract creation via CREATE2
+ * - EIP-4844 blob transactions
+ *
+ * For most use cases sending ETH or calling contracts, you'll want to provide `to`.
+ */
+export interface PrepareTransactionParams {
+  /** The Panna client instance */
+  client: PannaClient;
+  /** The chain to execute on */
+  chain: Chain;
+  /**
+   * The recipient address. Optional for contract deployment transactions.
+   * For regular transfers and contract calls, this should be provided.
+   */
+  to?: string;
+  /** The value to send (in wei) */
+  value?: bigint;
+  /** The transaction data */
+  data?: string;
+  /** Gas limit for the transaction */
+  gas?: bigint;
+  /** Gas price for legacy transactions */
+  gasPrice?: bigint;
+  /** Maximum fee per gas for EIP-1559 transactions */
+  maxFeePerGas?: bigint;
+  /** Maximum priority fee per gas for EIP-1559 transactions */
+  maxPriorityFeePerGas?: bigint;
+  /** Transaction nonce */
+  nonce?: number;
+  /** Additional gas to add to the estimated gas */
+  extraGas?: bigint;
+  /** Access list for EIP-2930 transactions */
+  accessList?: Array<{
+    address: string;
+    storageKeys: string[];
+  }>;
+}
+
+/**
+ * Result from preparing a transaction
+ */
+export interface PrepareTransactionResult {
+  /** The Panna client instance */
+  client: PannaClient;
+  /** The chain to execute on */
+  chain: Chain;
+  /** The recipient address (optional for contract deployments) */
+  to?: string;
+  /** The value to send (in wei) */
+  value?: bigint;
+  /** The transaction data */
+  data?: string;
+  /** Gas limit for the transaction */
+  gas?: bigint;
+  /** Gas price for legacy transactions */
+  gasPrice?: bigint;
+  /** Maximum fee per gas for EIP-1559 transactions */
+  maxFeePerGas?: bigint;
+  /** Maximum priority fee per gas for EIP-1559 transactions */
+  maxPriorityFeePerGas?: bigint;
+  /** Transaction nonce */
+  nonce?: number;
+  /** Additional gas to add to the estimated gas */
+  extraGas?: bigint;
+  /** Access list for EIP-2930 transactions */
+  accessList?: Array<{
+    address: string;
+    storageKeys: string[];
+  }>;
+}
+
+/**
+ * Parameters for preparing a contract call
+ */
+export interface PrepareContractCallParams {
+  /** The contract instance */
+  contract: {
+    /** The Panna client instance */
+    client: PannaClient;
+    /** The contract address */
+    address: string;
+    /** The chain the contract is deployed on */
+    chain: Chain;
+    /** The contract ABI (optional for basic interactions) */
+    abi?: Abi;
+  };
+  /** The method signature or ABI function */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  method: string | any;
+  /** The parameters for the method call */
+  params?: unknown[];
+  /** The value to send with the transaction (in wei) */
+  value?: bigint;
+  /** Gas limit for the transaction */
+  gas?: bigint;
+  /** Gas price for legacy transactions */
+  gasPrice?: bigint;
+  /** Maximum fee per gas for EIP-1559 transactions */
+  maxFeePerGas?: bigint;
+  /** Maximum priority fee per gas for EIP-1559 transactions */
+  maxPriorityFeePerGas?: bigint;
+  /** Transaction nonce */
+  nonce?: number;
+  /** Additional gas to add to the estimated gas */
+  extraGas?: bigint;
+  /** Access list for EIP-2930 transactions */
+  accessList?: Array<{
+    address: string;
+    storageKeys: string[];
+  }>;
+}
+
+/**
+ * Result from preparing a contract call
+ *
+ * Note: The data field is a function that returns transaction data when called.
+ * This is a lazy evaluation pattern - users should not call this function directly.
+ * Instead, pass the entire transaction object to sendTransaction which handles data resolution.
+ */
+export interface PrepareContractCallResult {
+  /** The recipient address */
+  to: string;
+  /** The transaction data as a lazy-evaluated function */
+  data: () => Promise<string>;
+  /** The value to send with the transaction (in wei) */
+  value?: bigint;
+  /** The chain the contract is deployed on */
+  chain?: Chain;
+}
+
+/**
+ * Parameters for getting a contract instance
+ */
+export interface GetContractParams {
+  /** The Panna client instance */
+  client: PannaClient;
+  /** The contract address */
+  address: string;
+  /** The contract ABI (optional for basic interactions) */
+  abi?: Abi;
+  /** The chain the contract is deployed on */
+  chain: Chain;
+}
+
+/**
+ * Result from getting a contract instance
+ */
+export interface GetContractResult {
+  /** The Panna client instance */
+  client: PannaClient;
+  /** The contract address */
+  address: string;
+  /** The contract ABI */
+  abi?: Abi;
+  /** The chain the contract is deployed on */
+  chain: Chain;
+}

--- a/packages/panna-sdk/src/core/utils/utils.test.ts
+++ b/packages/panna-sdk/src/core/utils/utils.test.ts
@@ -18,7 +18,8 @@ import {
   accountBalanceInFiat,
   accountBalancesInFiat,
   getFiatPrice,
-  getSocialIcon
+  getSocialIcon,
+  toWei
 } from './utils';
 import * as utils from './utils';
 
@@ -1249,6 +1250,29 @@ describe('Utils - Unit Tests', () => {
       expect(result.errors).toBeUndefined();
       expect(result.tokenBalances).toHaveLength(1);
       expect(result.totalValue.amount).toBe(3000.0);
+    });
+  });
+
+  describe('toWei', () => {
+    it('should convert string tokens to wei bigint', () => {
+      const result = toWei('1');
+      expect(result).toBe(BigInt('1000000000000000000'));
+      expect(typeof result).toBe('bigint');
+    });
+
+    it('should handle decimal values', () => {
+      const result = toWei('1.5');
+      expect(result).toBe(BigInt('1500000000000000000'));
+    });
+
+    it('should handle small decimal values', () => {
+      const result = toWei('0.001');
+      expect(result).toBe(BigInt('1000000000000000'));
+    });
+
+    it('should handle zero', () => {
+      const result = toWei('0');
+      expect(result).toBe(BigInt('0'));
     });
   });
 });

--- a/packages/panna-sdk/src/core/utils/utils.ts
+++ b/packages/panna-sdk/src/core/utils/utils.ts
@@ -1,4 +1,5 @@
 import { convertCryptoToFiat } from 'thirdweb/pay';
+import { toWei as thirdwebToWei } from 'thirdweb/utils';
 import { getWalletBalance } from 'thirdweb/wallets';
 import { getSocialIcon as thirdwebGetSocialIcon } from 'thirdweb/wallets/in-app';
 import {
@@ -19,6 +20,21 @@ import {
   type SocialProvider,
   type TokenBalanceError
 } from './types';
+
+/**
+ * Converts the specified number of tokens to Wei.
+ * @param tokens The number of tokens to convert.
+ * @returns The converted value in Wei.
+ * @example
+ * ```ts
+ * import { toWei } from 'panna-sdk';
+ *
+ * const value = toWei('1.5'); // 1500000000000000000n
+ * ```
+ */
+export const toWei = function (tokens: string): bigint {
+  return thirdwebToWei(tokens);
+};
 
 /**
  * Get the balance of an account

--- a/packages/panna-sdk/src/index.ts
+++ b/packages/panna-sdk/src/index.ts
@@ -21,6 +21,11 @@ export {
   prepareLogin,
   unlinkAccount,
 
+  // Transaction functions
+  prepareTransaction,
+  prepareContractCall,
+  getContract,
+
   // Wallet/Account types and enums
   EcosystemId,
   LoginStrategy,
@@ -49,6 +54,7 @@ export {
   getSocialIcon,
   getFiatPrice,
   isValidAddress,
+  toWei,
 
   // Utils types
   type AccountBalanceParams,
@@ -87,6 +93,14 @@ export {
   type OnrampPrepareResult,
   type OnRampIntent,
   type OnrampPrepareParams,
+
+  // Transaction types
+  type PrepareTransactionParams,
+  type PrepareTransactionResult,
+  type PrepareContractCallParams,
+  type PrepareContractCallResult,
+  type GetContractParams,
+  type GetContractResult,
 
   // Constants
   DEFAULT_CURRENCY,


### PR DESCRIPTION
### What was the problem?

This PR resolves LISK-2255.

### How was it solved?

This PR exposes the `prepareContractCall`, `prepareTransaction` and [getContract](url) functions that allows developers to prepare and execute blockchain transactions directly with the Panna SDK. These functions provide full control over transaction preparation, including native token transfers, contract method calls and contract deployments.

The implementation wraps Thirdweb's transaction functions with Panna specific types and includes comprehensive test coverage.

Additionally, the `toWei` utility function is now available for convenient token amount conversions (it's a different one then available inside ethereum library; ours return `bigint` instead of `string`; we're actually exposing `thirdwebToWei` function from Thirdweb library).

### How was it tested?

New unit tests were written.