### PR TITLE
Update prepareContractCall to internally invoke getContract

### DIFF
--- a/packages/panna-sdk/src/core/transaction/transaction.test.ts
+++ b/packages/panna-sdk/src/core/transaction/transaction.test.ts
@@ -6,6 +6,7 @@ import {
   prepareContractCall,
   getContract
 } from './transaction';
+import * as transaction from './transaction';
 
 // Mock thirdweb module
 jest.mock('thirdweb', () => ({
@@ -13,6 +14,7 @@ jest.mock('thirdweb', () => ({
   prepareContractCall: jest.fn(),
   getContract: jest.fn()
 }));
+jest.mock('./transaction', () => jest.requireActual('./transaction'));
 
 describe('Transaction Functions', () => {
   const mockClient = { clientId: 'test-client' } as PannaClient;
@@ -25,6 +27,74 @@ describe('Transaction Functions', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('getContract', () => {
+    it('should get a contract instance with minimal parameters', () => {
+      const mockResult = {
+        client: mockClient,
+        address: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e' as `0x${string}`,
+        chain: mockChain
+      };
+
+      (thirdweb.getContract as jest.Mock).mockReturnValue(mockResult);
+
+      const params = {
+        client: mockClient,
+        address: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e' as `0x${string}`,
+        chain: mockChain
+      };
+
+      const result = getContract(params);
+
+      expect(thirdweb.getContract).toHaveBeenCalledWith({
+        client: mockClient,
+        address: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e' as `0x${string}`,
+        chain: mockChain
+      });
+      expect(result).toEqual(mockResult);
+    });
+
+    it('should get a contract instance with ABI', () => {
+      const mockAbi = [
+        {
+          type: 'function' as const,
+          name: 'transfer',
+          inputs: [
+            { type: 'address', name: 'to' },
+            { type: 'uint256', name: 'amount' }
+          ],
+          outputs: [],
+          stateMutability: 'nonpayable' as const
+        }
+      ];
+
+      const mockResult = {
+        client: mockClient,
+        address: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e' as `0x${string}`,
+        abi: mockAbi,
+        chain: mockChain
+      };
+
+      (thirdweb.getContract as jest.Mock).mockReturnValue(mockResult);
+
+      const params = {
+        client: mockClient,
+        address: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e' as `0x${string}`,
+        abi: mockAbi,
+        chain: mockChain
+      };
+
+      const result = getContract(params);
+
+      expect(thirdweb.getContract).toHaveBeenCalledWith({
+        client: mockClient,
+        address: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e' as `0x${string}`,
+        abi: mockAbi,
+        chain: mockChain
+      });
+      expect(result).toEqual(mockResult);
+    });
   });
 
   describe('prepareTransaction', () => {
@@ -149,15 +219,18 @@ describe('Transaction Functions', () => {
       };
 
       (thirdweb.prepareContractCall as jest.Mock).mockReturnValue(mockResult);
+      jest.spyOn(transaction, 'getContract').mockReturnValue(mockContract);
 
       const params = {
-        contract: mockContract,
+        ...mockContract,
         method: 'function transfer(address to, uint256 amount)',
         params: ['0x123456789', BigInt('1000000000000000000')]
       };
 
       const result = prepareContractCall(params);
 
+      expect(transaction.getContract).toHaveBeenCalledTimes(1);
+      expect(transaction.getContract).toHaveBeenCalledWith({ ...mockContract });
       expect(thirdweb.prepareContractCall).toHaveBeenCalledWith({
         contract: mockContract,
         method: 'function transfer(address to, uint256 amount)',
@@ -180,9 +253,10 @@ describe('Transaction Functions', () => {
       };
 
       (thirdweb.prepareContractCall as jest.Mock).mockReturnValue(mockResult);
+      jest.spyOn(transaction, 'getContract').mockReturnValue(mockContract);
 
       const params = {
-        contract: mockContract,
+        ...mockContract,
         method: 'function mint(address to)',
         params: ['0x123456789'],
         value: BigInt('100000000000000000')
@@ -190,6 +264,8 @@ describe('Transaction Functions', () => {
 
       const result = prepareContractCall(params);
 
+      expect(transaction.getContract).toHaveBeenCalledTimes(1);
+      expect(transaction.getContract).toHaveBeenCalledWith({ ...mockContract });
       expect(thirdweb.prepareContractCall).toHaveBeenCalledWith({
         contract: mockContract,
         method: 'function mint(address to)',
@@ -213,14 +289,17 @@ describe('Transaction Functions', () => {
       };
 
       (thirdweb.prepareContractCall as jest.Mock).mockReturnValue(mockResult);
+      jest.spyOn(transaction, 'getContract').mockReturnValue(mockContract);
 
       const params = {
-        contract: mockContract,
+        ...mockContract,
         method: 'function totalSupply()'
       };
 
       const result = prepareContractCall(params);
 
+      expect(transaction.getContract).toHaveBeenCalledTimes(1);
+      expect(transaction.getContract).toHaveBeenCalledWith({ ...mockContract });
       expect(thirdweb.prepareContractCall).toHaveBeenCalledWith({
         contract: mockContract,
         method: 'function totalSupply()',
@@ -253,15 +332,18 @@ describe('Transaction Functions', () => {
       };
 
       (thirdweb.prepareContractCall as jest.Mock).mockReturnValue(mockResult);
+      jest.spyOn(transaction, 'getContract').mockReturnValue(mockContract);
 
       const params = {
-        contract: mockContract,
+        ...mockContract,
         method: mockAbiFunction,
         params: ['0x123456789', BigInt('1000000000000000000')]
       };
 
       const result = prepareContractCall(params);
 
+      expect(transaction.getContract).toHaveBeenCalledTimes(1);
+      expect(transaction.getContract).toHaveBeenCalledWith({ ...mockContract });
       expect(thirdweb.prepareContractCall).toHaveBeenCalledWith({
         contract: mockContract,
         method: mockAbiFunction,
@@ -281,9 +363,10 @@ describe('Transaction Functions', () => {
         (thirdweb.prepareContractCall as jest.Mock).mockImplementation(() => {
           throw mockError;
         });
+        jest.spyOn(transaction, 'getContract').mockReturnValue(mockContract);
 
         const params = {
-          contract: mockContract,
+          ...mockContract,
           method: 'function nonExistentFunction()',
           params: []
         };
@@ -291,6 +374,11 @@ describe('Transaction Functions', () => {
         expect(() => prepareContractCall(params)).toThrow(
           'Contract does not contain method: nonExistentFunction'
         );
+
+        expect(transaction.getContract).toHaveBeenCalledTimes(1);
+        expect(transaction.getContract).toHaveBeenCalledWith({
+          ...mockContract
+        });
         expect(thirdweb.prepareContractCall).toHaveBeenCalledWith({
           contract: mockContract,
           method: 'function nonExistentFunction()',
@@ -303,9 +391,10 @@ describe('Transaction Functions', () => {
         (thirdweb.prepareContractCall as jest.Mock).mockImplementation(() => {
           throw mockError;
         });
+        jest.spyOn(transaction, 'getContract').mockReturnValue(mockContract);
 
         const params = {
-          contract: mockContract,
+          ...mockContract,
           method: 'malformed method signature',
           params: []
         };
@@ -313,6 +402,10 @@ describe('Transaction Functions', () => {
         expect(() => prepareContractCall(params)).toThrow(
           'Invalid method signature: malformed'
         );
+        expect(transaction.getContract).toHaveBeenCalledTimes(1);
+        expect(transaction.getContract).toHaveBeenCalledWith({
+          ...mockContract
+        });
         expect(thirdweb.prepareContractCall).toHaveBeenCalledWith({
           contract: mockContract,
           method: 'malformed method signature',
@@ -325,9 +418,10 @@ describe('Transaction Functions', () => {
         (thirdweb.prepareContractCall as jest.Mock).mockImplementation(() => {
           throw mockError;
         });
+        jest.spyOn(transaction, 'getContract').mockReturnValue(mockContract);
 
         const params = {
-          contract: mockContract,
+          ...mockContract,
           method: 'function transfer(address to, uint256 amount)',
           params: ['0x123456789'] // Missing amount parameter
         };
@@ -335,6 +429,10 @@ describe('Transaction Functions', () => {
         expect(() => prepareContractCall(params)).toThrow(
           'Expected 2 parameters but got 1'
         );
+        expect(transaction.getContract).toHaveBeenCalledTimes(1);
+        expect(transaction.getContract).toHaveBeenCalledWith({
+          ...mockContract
+        });
         expect(thirdweb.prepareContractCall).toHaveBeenCalledWith({
           contract: mockContract,
           method: 'function transfer(address to, uint256 amount)',
@@ -347,9 +445,10 @@ describe('Transaction Functions', () => {
         (thirdweb.prepareContractCall as jest.Mock).mockImplementation(() => {
           throw mockError;
         });
+        jest.spyOn(transaction, 'getContract').mockReturnValue(mockContract);
 
         const params = {
-          contract: mockContract,
+          ...mockContract,
           method: 'function transfer(address to, uint256 amount)',
           params: ['0x123456789', BigInt('1000000000000000000'), 'extraParam']
         };
@@ -357,6 +456,10 @@ describe('Transaction Functions', () => {
         expect(() => prepareContractCall(params)).toThrow(
           'Expected 2 parameters but got 3'
         );
+        expect(transaction.getContract).toHaveBeenCalledTimes(1);
+        expect(transaction.getContract).toHaveBeenCalledWith({
+          ...mockContract
+        });
         expect(thirdweb.prepareContractCall).toHaveBeenCalledWith({
           contract: mockContract,
           method: 'function transfer(address to, uint256 amount)',
@@ -371,9 +474,10 @@ describe('Transaction Functions', () => {
         (thirdweb.prepareContractCall as jest.Mock).mockImplementation(() => {
           throw mockError;
         });
+        jest.spyOn(transaction, 'getContract').mockReturnValue(mockContract);
 
         const params = {
-          contract: mockContract,
+          ...mockContract,
           method: 'function transfer(address to, uint256 amount)',
           params: ['0x123456789', 'invalidAmount'] // Should be BigInt, not string
         };
@@ -381,6 +485,10 @@ describe('Transaction Functions', () => {
         expect(() => prepareContractCall(params)).toThrow(
           'Parameter type mismatch: expected uint256 but got string'
         );
+        expect(transaction.getContract).toHaveBeenCalledTimes(1);
+        expect(transaction.getContract).toHaveBeenCalledWith({
+          ...mockContract
+        });
         expect(thirdweb.prepareContractCall).toHaveBeenCalledWith({
           contract: mockContract,
           method: 'function transfer(address to, uint256 amount)',
@@ -393,9 +501,10 @@ describe('Transaction Functions', () => {
         (thirdweb.prepareContractCall as jest.Mock).mockImplementation(() => {
           throw mockError;
         });
+        jest.spyOn(transaction, 'getContract').mockReturnValue(mockContract);
 
         const params = {
-          contract: mockContract,
+          ...mockContract,
           method: '',
           params: []
         };
@@ -403,6 +512,10 @@ describe('Transaction Functions', () => {
         expect(() => prepareContractCall(params)).toThrow(
           'Method cannot be empty'
         );
+        expect(transaction.getContract).toHaveBeenCalledTimes(1);
+        expect(transaction.getContract).toHaveBeenCalledWith({
+          ...mockContract
+        });
         expect(thirdweb.prepareContractCall).toHaveBeenCalledWith({
           contract: mockContract,
           method: '',
@@ -415,14 +528,19 @@ describe('Transaction Functions', () => {
         (thirdweb.prepareContractCall as jest.Mock).mockImplementation(() => {
           throw mockError;
         });
+        jest.spyOn(transaction, 'getContract').mockReturnValue(mockContract);
 
         const params = {
-          contract: mockContract,
+          ...mockContract,
           method: undefined as unknown as string,
           params: []
         };
 
         expect(() => prepareContractCall(params)).toThrow('Method is required');
+        expect(transaction.getContract).toHaveBeenCalledTimes(1);
+        expect(transaction.getContract).toHaveBeenCalledWith({
+          ...mockContract
+        });
         expect(thirdweb.prepareContractCall).toHaveBeenCalledWith({
           contract: mockContract,
           method: undefined,
@@ -445,9 +563,10 @@ describe('Transaction Functions', () => {
         (thirdweb.prepareContractCall as jest.Mock).mockImplementation(() => {
           throw mockError;
         });
+        jest.spyOn(transaction, 'getContract').mockReturnValue(mockContract);
 
         const params = {
-          contract: mockContract,
+          ...mockContract,
           method: nonExistentAbiFunction,
           params: []
         };
@@ -455,6 +574,10 @@ describe('Transaction Functions', () => {
         expect(() => prepareContractCall(params)).toThrow(
           'Function nonExistentFunction not found in contract ABI'
         );
+        expect(transaction.getContract).toHaveBeenCalledTimes(1);
+        expect(transaction.getContract).toHaveBeenCalledWith({
+          ...mockContract
+        });
         expect(thirdweb.prepareContractCall).toHaveBeenCalledWith({
           contract: mockContract,
           method: nonExistentAbiFunction,
@@ -480,9 +603,10 @@ describe('Transaction Functions', () => {
         (thirdweb.prepareContractCall as jest.Mock).mockImplementation(() => {
           throw mockError;
         });
+        jest.spyOn(transaction, 'getContract').mockReturnValue(mockContract);
 
         const params = {
-          contract: mockContract,
+          ...mockContract,
           method: transferAbiFunction,
           params: [] // Should have 2 parameters
         };
@@ -490,80 +614,16 @@ describe('Transaction Functions', () => {
         expect(() => prepareContractCall(params)).toThrow(
           'Function transfer requires 2 parameters but 0 provided'
         );
+        expect(transaction.getContract).toHaveBeenCalledTimes(1);
+        expect(transaction.getContract).toHaveBeenCalledWith({
+          ...mockContract
+        });
         expect(thirdweb.prepareContractCall).toHaveBeenCalledWith({
           contract: mockContract,
           method: transferAbiFunction,
           params: []
         });
       });
-    });
-  });
-
-  describe('getContract', () => {
-    it('should get a contract instance with minimal parameters', () => {
-      const mockResult = {
-        client: mockClient,
-        address: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e' as `0x${string}`,
-        chain: mockChain
-      };
-
-      (thirdweb.getContract as jest.Mock).mockReturnValue(mockResult);
-
-      const params = {
-        client: mockClient,
-        address: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e' as `0x${string}`,
-        chain: mockChain
-      };
-
-      const result = getContract(params);
-
-      expect(thirdweb.getContract).toHaveBeenCalledWith({
-        client: mockClient,
-        address: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e' as `0x${string}`,
-        chain: mockChain
-      });
-      expect(result).toEqual(mockResult);
-    });
-
-    it('should get a contract instance with ABI', () => {
-      const mockAbi = [
-        {
-          type: 'function' as const,
-          name: 'transfer',
-          inputs: [
-            { type: 'address', name: 'to' },
-            { type: 'uint256', name: 'amount' }
-          ],
-          outputs: [],
-          stateMutability: 'nonpayable' as const
-        }
-      ];
-
-      const mockResult = {
-        client: mockClient,
-        address: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e' as `0x${string}`,
-        abi: mockAbi,
-        chain: mockChain
-      };
-
-      (thirdweb.getContract as jest.Mock).mockReturnValue(mockResult);
-
-      const params = {
-        client: mockClient,
-        address: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e' as `0x${string}`,
-        abi: mockAbi,
-        chain: mockChain
-      };
-
-      const result = getContract(params);
-
-      expect(thirdweb.getContract).toHaveBeenCalledWith({
-        client: mockClient,
-        address: '0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e' as `0x${string}`,
-        abi: mockAbi,
-        chain: mockChain
-      });
-      expect(result).toEqual(mockResult);
     });
   });
 });

--- a/packages/panna-sdk/src/core/transaction/transaction.test.ts
+++ b/packages/panna-sdk/src/core/transaction/transaction.test.ts
@@ -624,6 +624,27 @@ describe('Transaction Functions', () => {
           params: []
         });
       });
+
+      it('should throw error when getContract invocation fails', () => {
+        jest.spyOn(transaction, 'getContract').mockImplementation(() => {
+          throw new Error('Invalid input');
+        });
+
+        const params = {
+          ...mockContract,
+          address: '0xinvalidAddress' as `0x${string}`,
+          method: 'function transfer(address to, uint256 amount)',
+          params: ['0x123456789', BigInt('1000000000000000000')]
+        };
+
+        expect(() => prepareContractCall(params)).toThrow('Invalid input');
+        expect(transaction.getContract).toHaveBeenCalledTimes(1);
+        expect(transaction.getContract).toHaveBeenCalledWith({
+          ...mockContract,
+          address: params.address
+        });
+        expect(thirdweb.prepareContractCall).toHaveBeenCalledTimes(0);
+      });
     });
   });
 });

--- a/packages/panna-sdk/src/core/transaction/transaction.ts
+++ b/packages/panna-sdk/src/core/transaction/transaction.ts
@@ -317,14 +317,14 @@ export const prepareContractCall = (
  * // Without ABI - use string-based method signatures
  * const contract = getContract({
  *   client: pannaClient,
- *   chain: lisk
+ *   chain: lisk,
  *   address: "0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e",
  * });
  *
  * // With ABI - type-safe with autocompletion
  * const erc20Contract = getContract({
  *   client: pannaClient,
- *   chain: lisk
+ *   chain: lisk,
  *   address: "0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e",
  *   abi: erc20Abi, // Full type safety and autocompletion. Define this ABI in your code or import from your contract definitions
  * });

--- a/packages/panna-sdk/src/core/transaction/transaction.ts
+++ b/packages/panna-sdk/src/core/transaction/transaction.ts
@@ -68,9 +68,9 @@ import type {
  * });
  * ```
  */
-export function prepareTransaction(
+export const prepareTransaction = (
   params: PrepareTransactionParams
-): PrepareTransactionResult {
+): PrepareTransactionResult => {
   const {
     client,
     chain,
@@ -106,7 +106,7 @@ export function prepareTransaction(
   };
 
   return thirdwebPrepareTransaction(prepareParams) as PrepareTransactionResult;
-}
+};
 
 /**
  * Prepare a contract method call for execution
@@ -123,42 +123,40 @@ export function prepareTransaction(
  * when using ABI-based approaches.
  *
  * @param params - Parameters for preparing the contract call
- * @param params.contract - The contract instance (with or without ABI)
+ * @param params.client - The Panna client instance
+ * @param params.chain - The chain the contract is deployed on
+ * @param params.address - The contract address
+ * @param params.abi - (Optional) The contract ABI. When provided, enables type-safe method calls with autocompletion. When omitted, the SDK will attempt to resolve the ABI automatically or you can use string-based method signatures with `prepareContractCall`
  * @param params.method - The method signature, ABI function, or method name (when ABI is provided)
- * @param params.params - The parameters for the method call (types inferred from method)
- * @param params.value - The value to send with the transaction (in wei)
- * @param params.gas - Gas limit for the transaction
- * @param params.gasPrice - Gas price for legacy transactions
- * @param params.maxFeePerGas - Maximum fee per gas for EIP-1559 transactions
- * @param params.maxPriorityFeePerGas - Maximum priority fee per gas for EIP-1559
- * @param params.nonce - Transaction nonce
- * @param params.extraGas - Additional gas to add to the estimated gas
- * @param params.accessList - Access list for EIP-2930 transactions
+ * @param params.params - (Optional) The parameters for the method call (types are automatically inferred from method)
+ * @param params.value - (Optional) The value to send with the transaction (in wei)
+ * @param params.gas - (Optional) Gas limit for the transaction
+ * @param params.gasPrice - (Optional) Gas price for legacy transactions
+ * @param params.maxFeePerGas - (Optional) Maximum fee per gas for EIP-1559 transactions
+ * @param params.maxPriorityFeePerGas - (Optional) Maximum priority fee per gas for EIP-1559
+ * @param params.nonce - (Optional) Transaction nonce
+ * @param params.extraGas - (Optional) Additional gas to add to the estimated gas
+ * @param params.accessList - (Optional) Access list for EIP-2930 transactions
  * @returns Prepared contract call transaction
  *
  * @example
  * ```typescript
- * import { prepareContractCall, getContract, toWei, lisk } from 'panna-sdk';
- *
- * // Get a contract instance (without ABI - uses string method signatures)
- * const contract = getContract({
- *   client: pannaClient,
- *   address: "0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e",
- *   chain: lisk
- * });
+ * import { prepareContractCall, toWei, lisk } from 'panna-sdk';
  *
  * // 1. Basic usage with method signature (type-safe based on signature)
  * const transaction = prepareContractCall({
- *   contract,
+ *   client: pannaClient,
+ *   chain: lisk,
+ *   address: "0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e",
  *   method: "function transfer(address to, uint256 amount)",
  *   params: ["0x123...", toWei("100")]
  * });
  *
  * // 2. With full contract ABI (provides autocompletion and full type safety)
- * const erc20Contract = getContract({
+ * const typeSafeCall = prepareContractCall({
  *   client: pannaClient,
- *   address: "0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e",
  *   chain: lisk,
+ *   address: "0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e",
  *   abi: [
  *     {
  *       name: "transfer",
@@ -177,18 +175,16 @@ export function prepareTransaction(
  *       outputs: [],
  *       stateMutability: "payable"
  *     }
- *   ]
- * });
- *
- * const typeSafeCall = prepareContractCall({
- *   contract: erc20Contract,
+ *   ],
  *   method: "transfer", // Auto-completion and type inference from ABI
  *   params: ["0x123...", toWei("100")]
  * });
  *
  * // 3. Using ABI snippet (efficient for single method calls)
  * const snippetCall = prepareContractCall({
- *   contract,
+ *   client: pannaClient,
+ *   chain: lisk,
+ *   address: "0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e",
  *   method: {
  *     name: "mintTo",
  *     type: "function",
@@ -204,7 +200,9 @@ export function prepareTransaction(
  *
  * // 4. Payable function with value
  * const payableCall = prepareContractCall({
- *   contract,
+ *   client: pannaClient,
+ *   chain: lisk,
+ *   address: "0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e",
  *   method: "function mint(address to)",
  *   params: ["0x123..."],
  *   value: toWei("0.1") // 0.1 ETH
@@ -212,7 +210,9 @@ export function prepareTransaction(
  *
  * // 5. Advanced gas configuration (EIP-1559)
  * const advancedGasCall = prepareContractCall({
- *   contract,
+ *   client: pannaClient,
+ *   chain: lisk,
+ *   address: "0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e",
  *   method: "function transfer(address to, uint256 amount)",
  *   params: ["0x123...", toWei("100")],
  *   maxFeePerGas: BigInt(30000000000), // 30 gwei
@@ -223,7 +223,9 @@ export function prepareTransaction(
  * // 6. Error handling pattern
  * try {
  *   const transaction = prepareContractCall({
- *     contract,
+ *     client: pannaClient,
+ *     chain: lisk,
+ *     address: "0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e",
  *     method: "function nonExistentFunction()",
  *     params: []
  *   });
@@ -232,11 +234,14 @@ export function prepareTransaction(
  * }
  * ```
  */
-export function prepareContractCall(
+export const prepareContractCall = (
   params: PrepareContractCallParams
-): PrepareContractCallResult {
+): PrepareContractCallResult => {
   const {
-    contract,
+    client,
+    address,
+    chain,
+    abi,
     method,
     params: methodParams,
     value,
@@ -260,13 +265,10 @@ export function prepareContractCall(
     accessList
   };
 
+  const contract = getContract({ client, address, chain, abi });
+
   const callParams: {
-    contract: {
-      client: PannaClient;
-      address: `0x${string}`;
-      chain: Chain;
-      abi?: Abi;
-    };
+    contract: GetContractParams;
     method: any; // eslint-disable-line @typescript-eslint/no-explicit-any
     params: readonly any[]; // eslint-disable-line @typescript-eslint/no-explicit-any
     value?: bigint;
@@ -288,7 +290,7 @@ export function prepareContractCall(
   };
 
   return thirdwebPrepareContractCall(callParams) as PrepareContractCallResult;
-}
+};
 
 /**
  * Get a contract instance for interaction
@@ -301,9 +303,9 @@ export function prepareContractCall(
  *
  * @param params - Parameters for getting the contract
  * @param params.client - The Panna client instance
+ * @param params.chain - The chain the contract is deployed on
  * @param params.address - The contract address
  * @param params.abi - (Optional) The contract ABI. When provided, enables type-safe method calls with autocompletion. When omitted, the SDK will attempt to resolve the ABI automatically or you can use string-based method signatures with `prepareContractCall`
- * @param params.chain - The chain the contract is deployed on
  * @returns Contract instance ready for interaction
  *
  * @example
@@ -313,8 +315,8 @@ export function prepareContractCall(
  * // Without ABI - use string-based method signatures
  * const contract = getContract({
  *   client: pannaClient,
- *   address: "0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e",
  *   chain: lisk
+ *   address: "0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e",
  * });
  *
  * const tx1 = prepareContractCall({
@@ -326,9 +328,9 @@ export function prepareContractCall(
  * // With ABI - type-safe with autocompletion
  * const erc20Contract = getContract({
  *   client: pannaClient,
+ *   chain: lisk
  *   address: "0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e",
  *   abi: erc20Abi, // Full type safety and autocompletion. Define this ABI in your code or import from your contract definitions
- *   chain: lisk
  * });
  *
  * const tx2 = prepareContractCall({
@@ -338,7 +340,7 @@ export function prepareContractCall(
  * });
  * ```
  */
-export function getContract(params: GetContractParams): GetContractResult {
+export const getContract = (params: GetContractParams): GetContractResult => {
   const { client, address, abi, chain } = params;
 
   const optionalFields = { abi };
@@ -356,4 +358,4 @@ export function getContract(params: GetContractParams): GetContractResult {
   };
 
   return thirdwebGetContract(contractParams) as GetContractResult;
-}
+};

--- a/packages/panna-sdk/src/core/transaction/transaction.ts
+++ b/packages/panna-sdk/src/core/transaction/transaction.ts
@@ -138,6 +138,7 @@ export const prepareTransaction = (
  * @param params.extraGas - (Optional) Additional gas to add to the estimated gas
  * @param params.accessList - (Optional) Access list for EIP-2930 transactions
  * @returns Prepared contract call transaction
+ * @throws Error when invalid client, address or chain is provided
  *
  * @example
  * ```typescript
@@ -307,10 +308,11 @@ export const prepareContractCall = (
  * @param params.address - The contract address
  * @param params.abi - (Optional) The contract ABI. When provided, enables type-safe method calls with autocompletion. When omitted, the SDK will attempt to resolve the ABI automatically or you can use string-based method signatures with `prepareContractCall`
  * @returns Contract instance ready for interaction
+ * @throws Error when invalid client, address or chain is provided
  *
  * @example
  * ```typescript
- * import { getContract, prepareContractCall, lisk } from 'panna-sdk';
+ * import { getContract, lisk } from 'panna-sdk';
  *
  * // Without ABI - use string-based method signatures
  * const contract = getContract({
@@ -319,24 +321,12 @@ export const prepareContractCall = (
  *   address: "0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e",
  * });
  *
- * const tx1 = prepareContractCall({
- *   contract,
- *   method: "function transfer(address to, uint256 amount)", // String signature
- *   params: ["0x123...", BigInt("1000000000000000000")]
- * });
- *
  * // With ABI - type-safe with autocompletion
  * const erc20Contract = getContract({
  *   client: pannaClient,
  *   chain: lisk
  *   address: "0x742d35Cc6635C0532925a3b8D42f3C2544a3F97e",
  *   abi: erc20Abi, // Full type safety and autocompletion. Define this ABI in your code or import from your contract definitions
- * });
- *
- * const tx2 = prepareContractCall({
- *   contract: erc20Contract,
- *   method: "transfer", // Inferred from ABI with full type checking
- *   params: ["0x123...", BigInt("1000000000000000000")]
  * });
  * ```
  */

--- a/packages/panna-sdk/src/core/transaction/types.test.ts
+++ b/packages/panna-sdk/src/core/transaction/types.test.ts
@@ -111,18 +111,20 @@ describe('Transaction Types', () => {
   describe('PrepareContractCallParams', () => {
     it('should accept valid minimal parameters', () => {
       const params: PrepareContractCallParams = {
-        contract: mockContract,
+        ...mockContract,
         method: 'function totalSupply()'
       };
 
       expect(params).toBeDefined();
-      expect(params.contract).toBe(mockContract);
+      expect(params.client).toBe(mockContract.client);
+      expect(params.chain).toBe(mockContract.chain);
+      expect(params.address).toBe(mockContract.address);
       expect(params.method).toBe('function totalSupply()');
     });
 
     it('should accept gas parameters', () => {
       const params: PrepareContractCallParams = {
-        contract: mockContract,
+        ...mockContract,
         method: 'function transfer(address to, uint256 amount)',
         params: ['0x123456789', BigInt('1000000000000000000')],
         value: BigInt('100000000000000000'),
@@ -141,7 +143,7 @@ describe('Transaction Types', () => {
 
     it('should accept method with parameters', () => {
       const params: PrepareContractCallParams = {
-        contract: mockContract,
+        ...mockContract,
         method: 'function transfer(address to, uint256 amount)',
         params: ['0x123456789', BigInt('1000000000000000000')]
       };
@@ -154,7 +156,7 @@ describe('Transaction Types', () => {
 
     it('should accept value for payable methods', () => {
       const params: PrepareContractCallParams = {
-        contract: mockContract,
+        ...mockContract,
         method: 'function mint(address to)',
         params: ['0x123456789'],
         value: BigInt('100000000000000000')
@@ -174,7 +176,7 @@ describe('Transaction Types', () => {
       };
 
       const params: PrepareContractCallParams = {
-        contract: mockContract,
+        ...mockContract,
         method: abiFunction,
         params: ['0x123456789', BigInt('1000000000000000000')]
       };

--- a/packages/panna-sdk/src/core/transaction/types.ts
+++ b/packages/panna-sdk/src/core/transaction/types.ts
@@ -54,19 +54,7 @@ export type PrepareTransactionResult = PrepareTransactionParams;
 /**
  * Parameters for preparing a contract call
  */
-export interface PrepareContractCallParams {
-  /** The contract instance */
-  contract: {
-    /** The Panna client instance */
-    client: PannaClient;
-    /** The contract address */
-    address: `0x${string}`;
-    /** The chain the contract is deployed on */
-    chain: Chain;
-    /** The contract ABI (optional for basic interactions) */
-    abi?: Abi;
-  };
-  /** The method signature or ABI function */
+export interface PrepareContractCallParams extends GetContractParams {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   method: string | any;
   /** The parameters for the method call */


### PR DESCRIPTION
## Summary

To avoid developers from calling two separate functions,  `prepareCollectible` was planned to encapsulate all the necessary calls in a single invocation.

However, the suggested naming was quite specific to a certain activity while it could be used in a more generic manner. Hence, to keep the nomenclature generic `prepareContractCall` was updated with the expected behaviour.

## Rationale

In the summary.

## Changes

- Existing logic for `prepareContractCall` was updated
- Existing test cases were updated

## Impact

NA

## Testing

Unit tests

## Screenshots/Video

Include screenshots or video demonstrating the new feature, if applicable.

## Checklist

- [x] Code follows the project's coding standards

- [x] Unit tests covering the new feature have been added

- [x] All existing tests pass

- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

Any additional information or context relevant to this PR.
