### PR TITLE
Integrate fiat currency limits API in onramp amount

### DIFF
--- a/packages/panna-sdk/src/core/util/types.ts
+++ b/packages/panna-sdk/src/core/util/types.ts
@@ -171,6 +171,34 @@ export enum FiatCurrency {
   ZMW = 'ZMW' // Zambian Kwacha
 }
 
+export enum FiatLimitsEnum {
+  ONRAMP = 'onramp',
+  OFFRAMP = 'offramp',
+  BOTH = 'both'
+}
+
+export type FiatLimitsParams =
+  (typeof FiatLimitsEnum)[keyof typeof FiatLimitsEnum];
+
+export type FiatLimitsData = Partial<{
+  onramp: {
+    [key in FiatCurrency]: {
+      min: number;
+      max: number;
+    };
+  };
+  offramp: {
+    [key in FiatCurrency]: {
+      min: number;
+      max: number;
+    };
+  };
+}>;
+
+export type FiatLimitsResponse = FiatLimitsData & {
+  success: boolean;
+};
+
 // Parameters for getting fiat price
 export interface GetFiatPriceParams {
   client: PannaClient;

--- a/packages/panna-sdk/src/react/hooks/use-fiat-currency-limits.ts
+++ b/packages/panna-sdk/src/react/hooks/use-fiat-currency-limits.ts
@@ -1,0 +1,35 @@
+import { useQuery } from '@tanstack/react-query';
+import { FiatLimitsData, FiatLimitsEnum, FiatLimitsParams } from 'src/core';
+import { DEFAULT_STALE_TIME } from './constants';
+import { usePanna } from './use-panna';
+
+export function useFiatCurrencyLimits(params: FiatLimitsParams) {
+  const { pannaApiService, siweAuth } = usePanna();
+
+  const hasValidParams =
+    params === FiatLimitsEnum.ONRAMP ||
+    params === FiatLimitsEnum.OFFRAMP ||
+    params === FiatLimitsEnum.BOTH;
+
+  return useQuery<FiatLimitsData, Error>({
+    queryKey: ['fiat-limits', params],
+    queryFn: async () => {
+      const authToken = await siweAuth.getValidAuthToken();
+
+      if (!authToken) {
+        throw new Error('Missing authentication token for onramp quotes.');
+      }
+
+      return pannaApiService.getFiatCurrencyLimits(params, authToken);
+    },
+    enabled: hasValidParams,
+    staleTime: DEFAULT_STALE_TIME,
+    retry: (failureCount, error) => {
+      // Don't retry if it's an authentication error to avoid multiple retry attempts
+      if (error.message.includes('authentication token')) {
+        return false;
+      }
+      return failureCount < 3;
+    }
+  });
+}

--- a/packages/panna-sdk/src/react/utils/amount.ts
+++ b/packages/panna-sdk/src/react/utils/amount.ts
@@ -1,0 +1,16 @@
+export function formatWithCommas(value: number | string): string {
+  const str = typeof value === 'number' ? value.toString() : value;
+
+  if (str === '' || str === '.') return str;
+
+  const [integerPart, decimalPart] = str.split('.');
+  const digitsOnly = integerPart.replace(/\D/g, '');
+
+  if (digitsOnly === '') return decimalPart ? `0.${decimalPart}` : '0';
+
+  const withCommas = digitsOnly.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+
+  return decimalPart !== undefined
+    ? `${withCommas}.${decimalPart}`
+    : withCommas;
+}

--- a/packages/panna-sdk/src/react/utils/index.ts
+++ b/packages/panna-sdk/src/react/utils/index.ts
@@ -3,3 +3,4 @@ export * from './utils';
 export * from './countries';
 export * from './address';
 export * from './query-utils';
+export * from './amount';


### PR DESCRIPTION
## Summary

This PR integrates the Fiat Currency Limits API into the onramp flow, replacing hardcoded min/max transaction limits with dynamic values fetched from the Panna API. The buy flow now displays currency-specific limits based on the user's selected country and validates amounts against these limits in real-time.

## Rationale

Previously, the onramp buy flow used hardcoded transaction limits (e.g., $25, $50, $100), which didn't reflect actual provider constraints or support multiple currencies. This created a poor user experience where:
- Users could enter amounts outside the supported range
- The same limits were shown regardless of currency
- Limits couldn't be updated without a code deployment

By integrating with the Fiat Currency Limits API, the SDK now provides:
- **Dynamic limits**: Min/max values are fetched from the API based on currency and transaction type
- **Better validation**: Users receive immediate feedback when entering invalid amounts
- **Currency awareness**: Each fiat currency (USD, EUR, etc.) can have different limits
- **Future-proof**: Limit changes can be made server-side without SDK updates

## Changes

### Core SDK (`packages/panna-sdk/src/core/`)

- **New types in `util/types.ts`** (lines 174-200):
  - `FiatLimitsEnum`: Enum for limit types (`onramp`, `offramp`, `both`)
  - `FiatLimitsParams`: Type for API request parameters
  - `FiatLimitsData`: Response data structure with min/max per currency
  - `FiatLimitsResponse`: API response wrapper with success flag

- **New API method in `util/api-service.ts`** (lines 567-620):
  - `getFiatCurrencyLimits()`: Fetches limits from `/onramp/limits?type={type}` endpoint
  - Includes mock data support for development/testing
  - Requires authentication token

### React Components (`packages/panna-sdk/src/react/`)

- **New hook: `hooks/use-fiat-currency-limits.ts`**:
  - React Query hook wrapping the API service call
  - Automatic retry logic with auth error handling
  - Caching with default stale time
  - Validates params before making requests

- **New utility: `utils/amount.ts`**:
  - `formatWithCommas()`: Formats numbers with thousands separators
  - Handles both integer and decimal values
  - Preserves decimal precision for currency display

- **Updated: `components/buy/specify-buy-amount-step.tsx`**:
  - Integrates `useFiatCurrencyLimits` hook
  - Dynamic validation schema based on API-provided limits
  - Preset amount buttons now use `min`, `min * 2`, and `max` from API
  - Graceful fallback to hardcoded values (25, 50, 100) if API fails
  - Error messages display formatted amounts with currency symbols
  - Loading state while limits are being fetched

## Impact

### User Experience
- **Positive**: Users see accurate, currency-specific transaction limits
- **Positive**: Better error messages with formatted currency values (e.g., "$1,000" instead of "1000")
- **Positive**: Preset buttons adapt to available limits for each currency
- **Neutral**: Requires API call on buy flow initialization (cached after first load)

### Existing Functionality
- **No breaking changes**: Component maintains same interface
- **Backwards compatible**: Falls back to hardcoded limits if API fails
- **Auth requirement**: Requires user to be authenticated (already the case for buy flow)

### Performance
- **Minimal impact**: Single API call per currency/session (React Query caching)
- **Optimistic**: Form remains usable while limits are loading

## Testing

This PR has been tested manually and using unit tests.

## Screenshots/Video

UI changes are minimal - preset buttons now show dynamic values (e.g., $10, $20, $1,000 for USD instead of $25, $50, $100), and error messages include formatted currency amounts.

## Checklist

- [x] Code follows the project's coding standards

- [x] Unit tests covering the new feature have been added

- [x] All existing tests pass

- [x] The documentation has been updated to reflect the new feature